### PR TITLE
Update for new admin panel at my.pay.nl

### DIFF
--- a/src/Integration.php
+++ b/src/Integration.php
@@ -3,6 +3,7 @@
 namespace Pronamic\WordPress\Pay\Gateways\PayNL;
 
 use Pronamic\WordPress\Pay\AbstractGatewayIntegration;
+use Pronamic\WordPress\Pay\Payments\Payment;
 
 /**
  * Title: Pay.nl integration
@@ -36,6 +37,8 @@ class Integration extends AbstractGatewayIntegration {
 		);
 
 		parent::__construct( $args );
+
+		add_filter( 'pronamic_payment_provider_url_pay_nl', [ $this, 'payment_provider_url' ], 10, 2 );
 	}
 
 	/**
@@ -81,6 +84,26 @@ class Integration extends AbstractGatewayIntegration {
 
 		// Return fields.
 		return $fields;
+	}
+
+	/**
+	 * Payment provider URL.
+	 *
+	 * @param string|null $url     Payment provider URL.
+	 * @param Payment     $payment Payment.
+	 * @return string|null
+	 */
+	public function payment_provider_url( ?string $url, Payment $payment ): ?string {
+		$transaction_id = $payment->get_transaction_id();
+
+		if ( null === $transaction_id ) {
+			return $url;
+		}
+
+		return sprintf(
+			'https://my.pay.nl/transactions/details/%s',
+			$transaction_id
+		);
 	}
 
 	public function get_config( $post_id ) {

--- a/src/Integration.php
+++ b/src/Integration.php
@@ -28,7 +28,7 @@ class Integration extends AbstractGatewayIntegration {
 				'name'          => 'Pay.nl',
 				'url'           => 'https://www.pay.nl/',
 				'product_url'   => 'https://www.pay.nl/',
-				'dashboard_url' => 'https://admin.pay.nl/',
+				'dashboard_url' => 'https://my.pay.nl/',
 				'register_url'  => 'https://www.pay.nl/registreren/?id=M-7393-3100',
 				'provider'      => 'pay_nl',
 				'manual_url'    => \__( 'https://www.pronamic.eu/support/how-to-connect-pay-nl-with-wordpress-via-pronamic-pay/', 'pronamic_ideal' ),


### PR DESCRIPTION
This PR resolves #2.

I also added the `pronamic_payment_provider_url_pay_nl` filter with a link to the new admin panel. Unfortunately, the linked page does not include the normal admin UI (header, navigation, etc.). We might get a reply to https://twitter.com/rvdsteege/status/1577946039012806656 and can always update the URL then if necessary.

> Gefeliciteerd met het nieuwe admin panel! Vraagje voor in onze [@Pronamic](https://twitter.com/pronamic) Pay plugin voor [#WordPress](https://twitter.com/hashtag/WordPress?src=hashtag_click): is er ook een mooie manier om naar een transactie te linken binnen het dashboard? Zoals https://my.pay.nl/transactions/details/1886196252X12159, maar dan mét behoud van navigatie etc.?

I've sent a reminder to support@pay.nl about direct linking to transactions:

> Beste Reüel,
> 
> Bedankt voor je bericht! Excuses dat hier via Twitter niet op is gereageerd. Ik ga je feedback doorzetten naar de collega's die verantwoordelijk zijn voor de nieuwe Admin. 
> 
> Met vriendelijke groet / Best regards,
>  
> Loes Bruinenberg
> Merchant support